### PR TITLE
Fix np.int deprecation error

### DIFF
--- a/tools/visualize/vis_utils.py
+++ b/tools/visualize/vis_utils.py
@@ -81,7 +81,7 @@ def plot_rect3d_on_img(img, num_rects, rect_corners, color=(0, 255, 0), thicknes
     """
     line_indices = ((0, 1), (0, 3), (0, 4), (1, 2), (1, 5), (3, 2), (3, 7), (4, 5), (4, 7), (2, 6), (5, 6), (6, 7))
     for i in range(num_rects):
-        corners = rect_corners[i].astype(np.int)
+        corners = rect_corners[i].astype(int)
 
         for start, end in line_indices:
             radius = 5


### PR DESCRIPTION
`np.int` is deprecated

when running
```
python3 tools/visualize/vis_label_in_image.py --path example-cooperative-vehicle-infrastructure/infrastructure-side --output-file ./vis_results
```

that would raise

```
AttributeError: module 'numpy' has no attribute 'int'.
`np.int` was a deprecated alias for the builtin `int`. To avoid this error in existing code, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.
The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations. Did you mean: 'inf'?
```